### PR TITLE
CLD-5600 Add upcall monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Virtual Switch (OVS) Exporter
 
-<a href="https://github.com/greenpau/ovs_exporter/actions/" target="_blank"><img src="https://github.com/greenpau/ovs_exporter/workflows/build/badge.svg?branch=main"></a>
+<a href="https://github.com/webnifico/ovs_exporter/actions/" target="_blank"><img src="https://github.com/webnifico/ovs_exporter/actions/workflows/main.yml/badge.svg?branch=main"></a>
 
 Export Open Virtual Switch (OVS) data to Prometheus.
 
@@ -16,12 +16,12 @@ This exporter exports metrics from the following OVS components:
 Run the following commands to install it:
 
 ```bash
-wget https://github.com/greenpau/ovs_exporter/releases/download/v1.0.4/ovs-exporter-1.0.4.linux-amd64.tar.gz
-tar xvzf ovs-exporter-1.0.4.linux-amd64.tar.gz
+wget https://github.com/webnifico/ovs_exporter/releases/download/v1.0.6/ovs-exporter-1.0.6.linux-amd64.tar.gz
+tar xvzf ovs-exporter-1.0.6.linux-amd64.tar.gz
 cd ovs-exporter*
 ./install.sh
 cd ..
-rm -rf ovs-exporter-1.0.4.linux-amd64*
+rm -rf ovs-exporter-1.0.6.linux-amd64*
 systemctl status ovs-exporter -l
 curl -s localhost:9475/metrics | grep server_id
 ```
@@ -29,13 +29,16 @@ curl -s localhost:9475/metrics | grep server_id
 Run the following commands to build and test it:
 
 ```bash
-cd $GOPATH/src
-mkdir -p github.com/greenpau
-cd github.com/greenpau
-git clone https://github.com/greenpau/ovs_exporter.git
+git clone https://github.com/webnifico/ovs_exporter.git
 cd ovs_exporter
 make
-make qtest
+go test ./... -run TestParseUpcallShowMetrics
+```
+
+For full host-level testing against a running Open vSwitch instance, use:
+
+```bash
+make test
 ```
 
 ## Exported Metrics
@@ -71,6 +74,12 @@ Next, package the binary:
 
 ```bash
 make BUILD_OS="linux" BUILD_ARCH="arm64" dist
+```
+
+The `qtest` target starts the exporter with `sudo` and expects local Open vSwitch sockets, so it is intended for host-level validation on an OVS node:
+
+```bash
+make qtest
 ```
 
 After a successful release, upload packages to Github:

--- a/pkg/ovs_exporter/ovs_exporter.go
+++ b/pkg/ovs_exporter/ovs_exporter.go
@@ -17,6 +17,10 @@ package ovs_exporter
 import (
 	"fmt"
 	_ "net/http/pprof"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -159,6 +163,26 @@ var (
 		prometheus.BuildFQName(namespace, "", "dp_masks_hit_ratio"),
 		"The average number of masks visited per packet. It is the ration between hit and total number of packets processed by a datapath.",
 		[]string{"system_id", "datapath"}, nil,
+	)
+	upcallFlows = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "upcall_flows"),
+		"Flow counters reported by upcall/show.",
+		[]string{"system_id", "component", "datapath", "kind"}, nil,
+	)
+	upcallDumpDurationMs = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "upcall_dump_duration_ms"),
+		"The duration in milliseconds of upcall flow dump.",
+		[]string{"system_id", "component", "datapath"}, nil,
+	)
+	upcallUfidEnabled = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "upcall_ufid_enabled"),
+		"Whether UFID is enabled in upcall/show output (1=true, 0=false).",
+		[]string{"system_id", "component", "datapath"}, nil,
+	)
+	upcallHandlerKeys = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "upcall_handler_keys"),
+		"The number of keys assigned to each upcall handler.",
+		[]string{"system_id", "component", "datapath", "handler"}, nil,
 	)
 	// OVS Interface
 	// Reference: http://www.openvswitch.org/support/dist-docs/ovs-vswitchd.conf.db.5.html
@@ -339,6 +363,24 @@ type Options struct {
 	Logger  log.Logger
 }
 
+type upcallMetrics struct {
+	datapath       string
+	flowsCurrent   float64
+	flowsAvg       float64
+	flowsMax       float64
+	flowsLimit     float64
+	dumpDurationMs float64
+	ufidEnabled    float64
+	handlerKeys    map[string]float64
+}
+
+var (
+	upcallFlowFieldsRegex   = regexp.MustCompile(`\((current|avg|max|limit)\s+([0-9]+)\)`)
+	upcallDumpDurationRegex = regexp.MustCompile(`^dump duration\s*:\s*([0-9]+)ms$`)
+	upcallUfidRegex         = regexp.MustCompile(`^ufid enabled\s*:\s*(true|false)$`)
+	upcallHandlerRegex      = regexp.MustCompile(`^([0-9]+):\s+\(keys\s+([0-9]+)\)$`)
+)
+
 // NewLogger returns an instance of logger.
 func NewLogger(logLevel string) (log.Logger, error) {
 	allowedLogLevel := &promlog.AllowedLevel{}
@@ -420,6 +462,10 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- dpMasksTotal
 	ch <- dpMasksHitRatio
 	ch <- dpLookupsLost
+	ch <- upcallFlows
+	ch <- upcallDumpDurationMs
+	ch <- upcallUfidEnabled
+	ch <- upcallHandlerKeys
 	ch <- interfaceMain
 	ch <- interfaceAdminState
 	ch <- interfaceLinkState
@@ -898,6 +944,93 @@ func (e *Exporter) GatherMetrics() {
 					"system_id", e.Client.System.ID,
 				)
 			}
+			if cmds["upcall/show"] && (component == "vswitchd-service") {
+				level.Debug(e.logger).Log(
+					"msg", "GatherMetrics() calls getAppUpcallMetrics()",
+					"component", component,
+					"system_id", e.Client.System.ID,
+				)
+				if metrics, err := e.getAppUpcallMetrics(component); err != nil {
+					level.Error(e.logger).Log(
+						"msg", "getAppUpcallMetrics() failed",
+						"component", component,
+						"system_id", e.Client.System.ID,
+						"error", err.Error(),
+					)
+					e.IncrementErrorCounter()
+				} else {
+					for _, metric := range metrics {
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallFlows,
+							prometheus.GaugeValue,
+							metric.flowsCurrent,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+							"current",
+						))
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallFlows,
+							prometheus.GaugeValue,
+							metric.flowsAvg,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+							"avg",
+						))
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallFlows,
+							prometheus.GaugeValue,
+							metric.flowsMax,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+							"max",
+						))
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallFlows,
+							prometheus.GaugeValue,
+							metric.flowsLimit,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+							"limit",
+						))
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallDumpDurationMs,
+							prometheus.GaugeValue,
+							metric.dumpDurationMs,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+						))
+						e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+							upcallUfidEnabled,
+							prometheus.GaugeValue,
+							metric.ufidEnabled,
+							e.Client.System.ID,
+							component,
+							metric.datapath,
+						))
+						for handler, keys := range metric.handlerKeys {
+							e.metrics = append(e.metrics, prometheus.MustNewConstMetric(
+								upcallHandlerKeys,
+								prometheus.GaugeValue,
+								keys,
+								e.Client.System.ID,
+								component,
+								metric.datapath,
+								handler,
+							))
+						}
+					}
+				}
+				level.Debug(e.logger).Log(
+					"msg", "GatherMetrics() completed getAppUpcallMetrics()",
+					"component", component,
+					"system_id", e.Client.System.ID,
+				)
+			}
 		}
 	}
 
@@ -1335,4 +1468,97 @@ func GetExporterName() string {
 // SetPollInterval sets exporter's polling interval.
 func (e *Exporter) SetPollInterval(i int64) {
 	e.pollInterval = i
+}
+
+func (e *Exporter) getAppUpcallMetrics(component string) ([]*upcallMetrics, error) {
+	var socket string
+	switch component {
+	case "vswitchd-service":
+		socket = e.Client.Service.Vswitchd.Socket.Control
+	default:
+		return nil, fmt.Errorf("the '%s' component is unsupported for '%s'", component, "upcall/show")
+	}
+
+	socket = strings.TrimPrefix(socket, "unix:")
+	output, err := exec.Command("ovs-appctl", "-t", socket, "upcall/show").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("the '%s' command failed for %s: %s: %s", "upcall/show", component, err, strings.TrimSpace(string(output)))
+	}
+	return parseUpcallShowMetrics(string(output))
+}
+
+func parseUpcallShowMetrics(output string) ([]*upcallMetrics, error) {
+	upcalls := []*upcallMetrics{}
+	var current *upcallMetrics
+
+	lines := strings.Split(strings.Trim(output, "\""), "\n")
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasSuffix(line, ":") {
+			current = &upcallMetrics{
+				datapath:    strings.TrimSuffix(line, ":"),
+				handlerKeys: make(map[string]float64),
+			}
+			upcalls = append(upcalls, current)
+			continue
+		}
+		if current == nil {
+			continue
+		}
+
+		if strings.HasPrefix(line, "flows") {
+			matches := upcallFlowFieldsRegex.FindAllStringSubmatch(line, -1)
+			for _, match := range matches {
+				if len(match) != 3 {
+					continue
+				}
+				value, err := strconv.ParseFloat(match[2], 64)
+				if err != nil {
+					continue
+				}
+				switch match[1] {
+				case "current":
+					current.flowsCurrent = value
+				case "avg":
+					current.flowsAvg = value
+				case "max":
+					current.flowsMax = value
+				case "limit":
+					current.flowsLimit = value
+				}
+			}
+			continue
+		}
+
+		if matches := upcallDumpDurationRegex.FindStringSubmatch(line); len(matches) == 2 {
+			if value, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				current.dumpDurationMs = value
+			}
+			continue
+		}
+
+		if matches := upcallUfidRegex.FindStringSubmatch(line); len(matches) == 2 {
+			if matches[1] == "true" {
+				current.ufidEnabled = 1
+			} else {
+				current.ufidEnabled = 0
+			}
+			continue
+		}
+
+		if matches := upcallHandlerRegex.FindStringSubmatch(line); len(matches) == 3 {
+			if keys, err := strconv.ParseFloat(matches[2], 64); err == nil {
+				current.handlerKeys[matches[1]] = keys
+			}
+		}
+	}
+
+	if len(upcalls) == 0 {
+		return upcalls, fmt.Errorf("the '%s' command returned no parseable data", "upcall/show")
+	}
+	return upcalls, nil
 }

--- a/pkg/ovs_exporter/ovs_exporter_upcall_test.go
+++ b/pkg/ovs_exporter/ovs_exporter_upcall_test.go
@@ -1,0 +1,46 @@
+package ovs_exporter
+
+import "testing"
+
+func TestParseUpcallShowMetrics(t *testing.T) {
+	output := `system@ovs-system:
+  flows         : (current 300) (avg 300) (max 295560) (limit 175500)
+  dump duration : 28ms
+  ufid enabled : true
+
+  762: (keys 30)
+  763: (keys 34)
+`
+
+	metrics, err := parseUpcallShowMetrics(output)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 datapath metric set, got %d", len(metrics))
+	}
+
+	got := metrics[0]
+	if got.datapath != "system@ovs-system" {
+		t.Fatalf("expected datapath system@ovs-system, got %s", got.datapath)
+	}
+	if got.flowsCurrent != 300 || got.flowsAvg != 300 || got.flowsMax != 295560 || got.flowsLimit != 175500 {
+		t.Fatalf("unexpected flow counters: %+v", got)
+	}
+	if got.dumpDurationMs != 28 {
+		t.Fatalf("expected dump duration 28ms, got %v", got.dumpDurationMs)
+	}
+	if got.ufidEnabled != 1 {
+		t.Fatalf("expected ufid enabled to be 1, got %v", got.ufidEnabled)
+	}
+	if got.handlerKeys["762"] != 30 || got.handlerKeys["763"] != 34 {
+		t.Fatalf("unexpected handler keys: %+v", got.handlerKeys)
+	}
+}
+
+func TestParseUpcallShowMetricsNoDatapath(t *testing.T) {
+	_, err := parseUpcallShowMetrics("flows         : (current 300) (avg 300) (max 295560) (limit 175500)")
+	if err == nil {
+		t.Fatal("expected parsing error when no datapath header is present")
+	}
+}


### PR DESCRIPTION
## Summary
- Add support for collecting `upcall/show` from `vswitchd-service` with `ovs-appctl`.
- Export new Prometheus metrics for upcall flow counters, dump duration, UFID enabled state, and handler key counts.
- Add parser unit tests for valid `upcall/show` output and the no-datapath error path.

## Testing

Make and test
```
make BUILD_OS="linux" BUILD_ARCH="arm64"
make BUILD_OS="linux" BUILD_ARCH="arm64" dist

root@hyper002-stg-jnb2:~# curl http://10.208.50.2:9476/metrics | grep -i upcall_flows
...
ovs_upcall_flows{component="vswitchd-service",datapath="system@ovs-system",kind="avg",system_id="e060d8fb-422b-4687-bf67-f473895a54f7"} 110029
ovs_upcall_flows{component="vswitchd-service",datapath="system@ovs-system",kind="avg",system_id="e060d8fb-422b-4687-bf67-f473895a54f7"} 289
```

Tested in: https://github.com/webnifico/cloud-main/pull/1605